### PR TITLE
Remove notice about Chromium requirement

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -30,9 +30,7 @@
       <div class='dialog-msg'>
         <p>Dweb.page is an <a href='https://github.com/PACTCare/Dweb.page' target='_blank'>open source</a> website,
           that allows you to share and search content on the distributed web.
-          The website works best on browsers based on <a
-            href='https://en.wikipedia.org/wiki/Chromium_(web_browser)#Other_browsers_based_on_Chromium'
-            target='_blank'>Chromium</a> (e.g., Chrome, Opera or Brave).
+          The website works best on modern web browsers (e.g., Chrome, Brave, Firefox, Opera).
           <br> To continue, please agree to our <a href="javascript:void(0)" id='toTerms'>Terms</a> and <a
             href="javascript:void(0)" id='toPrivacy'>Policies</a>.</p>
       </div>


### PR DESCRIPTION
Issue #6 was fixed, right? And #5 is open, but I don't know if it is fixed. So Firefox support should be ready?

I'm replacing here requirement for Chromium browsers to any modern web browser.

Also, your website **isn't distributed** in any way if you require users to use a browser engine (Chromium) from the biggest world corporation (Google)!